### PR TITLE
Revamp evaluation docs for better UX

### DIFF
--- a/development.mdx
+++ b/development.mdx
@@ -3,15 +3,15 @@ title: "Evaluation workflow"
 description: "Operationalize your evaluation program from idea to dashboard"
 ---
 
-Follow these loops to keep your evaluations sharp as models and products evolve.
-
 ## Map the lifecycle
+
+Successful evaluation programs move in tight loops. Revisit each stage frequently so insights stay fresh and actionable.
 
 <Diagram title="Evaluation lifecycle" height={320}>
   <DiagramNode x={10} y={50} title="Frame" description="Clarify the decision and select representative scenarios." icon="compass" />
-  <DiagramNode x={35} y={10} title="Design" description="Draft rubrics, success metrics, and reviewer guidance." icon="pen-ruler" />
-  <DiagramNode x={70} y={25} title="Collect" description="Source prompts, contexts, and gold answers if available." icon="boxes-packing" />
-  <DiagramNode x={85} y={70} title="Score" description="Run humans, LLM judges, or hybrid scoring pipelines." icon="scale-balanced" />
+  <DiagramNode x={35} y={10} title="Design" description="Draft rubrics, metrics, and reviewer guidance." icon="pen-ruler" />
+  <DiagramNode x={70} y={25} title="Collect" description="Source prompts, contexts, and gold answers." icon="boxes-packing" />
+  <DiagramNode x={85} y={70} title="Score" description="Run humans, LLM judges, or hybrid pipelines." icon="scale-balanced" />
   <DiagramNode x={45} y={85} title="Synthesize" description="Aggregate, visualize, and annotate findings." icon="chart-pie" />
   <DiagramConnector from={0} to={1} />
   <DiagramConnector from={1} to={2} />
@@ -20,45 +20,69 @@ Follow these loops to keep your evaluations sharp as models and products evolve.
   <DiagramConnector from={4} to={0} />
 </Diagram>
 
-Each loop should produce artifacts—rubrics, prompts, dashboards—that future you can reuse.
+<Info>
+Capture artifacts at every loop: changelogged rubrics, prompt sets, judge prompts, dashboards, and decision logs.
+</Info>
 
-## Tooling stack recommendations
+## Tooling stack
 
-| Layer | Purpose | Questions to ask |
+| Layer | Purpose | Key question |
 | --- | --- | --- |
-| Source control | Track rubric and prompt changes | Do we review diffs before shipping a new evaluation? |
-| Data warehouse | Store prompts, responses, and scores | Can we join with product telemetry to understand impact? |
-| Orchestration | Automate runs | Can we schedule nightly sweeps and on-demand experiments? |
-| Analytics | Share insights | Can stakeholders self-serve trends and drill into examples? |
+| Source control | Track rubric and prompt changes | Do we review diffs before shipping updates? |
+| Data warehouse | Store prompts, responses, and scores | Can we join with product telemetry to show impact? |
+| Orchestration | Automate scheduled and on-demand runs | Can anyone trigger a sweep without engineering support? |
+| Analytics | Share insights broadly | Do stakeholders self-serve trends and drill into examples? |
 
-## Guardrails for human-in-the-loop runs
+<Tip>
+Adopt lightweight templates for run logs and score exports. Consistency speeds audits and onboarding.
+</Tip>
 
-<Accordion>
-  <AccordionItem title="Recruit intentionally">
-    Invite reviewers who represent the diversity of your user base. Rotate them periodically to avoid fatigue and bias creep.
-  </AccordionItem>
-  <AccordionItem title="Train before scoring">
-    Walk through the rubric together, calibrate with example outputs, and capture disagreements as future training data.
-  </AccordionItem>
-  <AccordionItem title="Protect well-being">
-    Some evals involve sensitive content. Offer opt-outs, provide support resources, and remove traumatic prompts when possible.
-  </AccordionItem>
+## Human-in-the-loop guardrails
+
+<AccordionGroup>
+<Accordion title="Recruit intentionally">
+Invite reviewers who mirror your user base. Rotate assignments to manage fatigue and surface new perspectives.
 </Accordion>
 
-## Automate with empathy
+<Accordion title="Train before scoring">
+Walk through the rubric together, calibrate on borderline examples, and document points of confusion.
+</Accordion>
 
-Automation accelerates feedback, but keep humans in the loop to catch nuance. Combine approaches:
+<Accordion title="Protect well-being">
+Flag sensitive content in advance, provide opt-out paths, and partner with HR for support resources.
+</Accordion>
+</AccordionGroup>
 
-- **Heuristics:** Lightweight rules that catch obvious failures (PII leaks, policy violations).
-- **Model judges:** LLMs prompted with your rubric to pre-score outputs. Sample human audits ensure alignment.
-- **Live telemetry:** Instrument production flows to surface eval-triggering events, like repeated user edits or conversation abandonment.
+<Warning>
+Never surprise reviewers with traumatic content. Redact or remove prompts that violate your organization’s safety policies.
+</Warning>
+
+## Automation with empathy
+
+Automation accelerates coverage, but humans keep nuance. Combine approaches based on risk tolerance.
+
+- **Heuristics:** Lightweight rules that catch policy violations or technical failures.
+- **LLM judges:** Prompt models with your rubric to pre-score outputs. Sample human audits validate alignment.
+- **Live telemetry:** Instrument production flows to flag regressions triggered by real user behavior.
+
+<Note>
+Track agreement between humans and automated judges. A drop in agreement is an early indicator that rubrics or prompts need attention.
+</Note>
 
 ## Close the loop
 
-End every run with a narrative:
+<Steps>
+<Step title="Synthesize findings">
+Publish a narrative summary that highlights top wins, regressions, and surprises.
+</Step>
+<Step title="Link evidence">
+Attach transcripts, screenshots, and reproduction steps so product teams can act quickly.
+</Step>
+<Step title="Assign owners">
+Create follow-up tickets with clear owners and due dates. Confirm fixes in the next evaluation run.
+</Step>
+</Steps>
 
-1. Summarize the top wins and regressions in plain language.
-2. Link to reproduction steps or raw conversations.
-3. Assign owners and due dates for follow-up experiments.
-
-When teams act on eval results quickly, models improve faster and trust grows across the organization.
+<Check>
+End every run with a shared decision: ship, iterate, or halt. Clarity keeps momentum and builds trust in the evaluation program.
+</Check>

--- a/guides/data.mdx
+++ b/guides/data.mdx
@@ -4,42 +4,70 @@ description: "Curate evaluation datasets that stay relevant"
 icon: "database"
 ---
 
-Your evaluation is only as good as the scenarios it covers. Treat prompt curation like product research.
-
 ## Build a scenario library
 
-1. **Source widely.** Pull examples from support tickets, search logs, UX research, and synthetic stress tests.
-2. **Label context.** Tag each scenario with metadata such as persona, language, risk level, and product surface.
-3. **Store history.** Keep retired prompts in an archive—you may need them when regressions return.
+Treat evaluation data like a living research repository.
+
+<Steps>
+<Step title="Source widely">
+Pull prompts from support tickets, search logs, UX research, synthetic stress tests, and proactive red-team exercises.
+</Step>
+<Step title="Tag context">
+Label each scenario with persona, language, risk level, product surface, and freshness date.
+</Step>
+<Step title="Archive history">
+Keep retired prompts and explain why they left rotation. Past regressions resurface when conditions change.
+</Step>
+</Steps>
 
 ## Refresh with intention
 
-<Accordion>
-  <AccordionItem title="Cadence">
-    Review your library every sprint. Rotate 10–20% of prompts to avoid overfitting and cover new capabilities.
-  </AccordionItem>
-  <AccordionItem title="Diversity">
-    Check that your dataset represents the voices you serve. Monitor distributions by region, language, accessibility needs, and expertise level.
-  </AccordionItem>
-  <AccordionItem title="Ethics">
-    Establish a review council for sensitive prompts. Get sign-off before introducing content that may trigger trauma or legal exposure.
-  </AccordionItem>
+<AccordionGroup>
+<Accordion title="Cadence">
+Review the dataset every sprint. Rotate 10–20% of prompts to cover new features and prevent overfitting.
 </Accordion>
+<Accordion title="Representation">
+Compare your dataset distribution to your real user base. Balance languages, accessibility needs, expertise levels, and risk tiers.
+</Accordion>
+<Accordion title="Ethics">
+Establish a review council for sensitive content. Obtain consent where required and document redaction rules.
+</Accordion>
+</AccordionGroup>
 
-## Collect gold answers (when possible)
+<Warning>
+Never store personal data in evaluation logs without encryption and access controls that match production standards.
+</Warning>
 
-- **Leverage SMEs.** Invite subject-matter experts to draft model answers for high-stakes scenarios.
-- **Capture rationale.** Ask SMEs to explain *why* their answer is correct. The rationale can power future rubrics and fine-tuning.
-- **Track freshness.** Note when ground truth expires (e.g., policy or pricing updates) and set reminders to refresh.
+## Capture gold answers
 
-## Handle production data responsibly
+- Partner with subject-matter experts to draft ideal responses for critical scenarios.
+- Ask contributors to explain *why* their answer is correct. Rationales power future rubrics and LLM judge prompts.
+- Track expiration dates for ground truth tied to policy, pricing, or product changes.
 
-<Callout icon="shield" color="rose">
-When sampling real user conversations, scrub personal data, secure storage, and obtain consent where required. High-quality evals should enhance trust, not erode it.
-</Callout>
+## Use production data responsibly
 
-## Collaborate with data partners
+<Note>
+Mask identifiers before exporting data. Align with legal and privacy teams on retention periods and deletion workflows.
+</Note>
 
-- Align with data engineering on schemas and retention policies.
-- Share evaluation insights with analytics teams to influence data collection roadmaps.
-- Offer product squads a "prompt of the week" so they feel the pulse of real user challenges.
+<Steps>
+<Step title="Scrub sensitive details">
+Remove personal identifiers, account numbers, and secrets before sharing prompts.
+</Step>
+<Step title="Secure storage">
+Store evaluation datasets in systems with audit trails, role-based access, and incident response plans.
+</Step>
+<Step title="Communicate purpose">
+Inform data owners and reviewers how the dataset supports quality improvements.
+</Step>
+</Steps>
+
+## Collaborate across teams
+
+- Share evaluation insights with analytics and research partners to influence data collection roadmaps.
+- Offer product squads a "prompt of the week" spotlight so they stay close to user realities.
+- Invite policy and legal stakeholders to quarterly reviews to confirm coverage of regulated scenarios.
+
+<Check>
+If every partner understands how their contributions shape the dataset, your evaluation program stays relevant and trusted.
+</Check>

--- a/guides/metrics.mdx
+++ b/guides/metrics.mdx
@@ -4,43 +4,67 @@ description: "Blend quantitative signals with qualitative judgment"
 icon: "ruler"
 ---
 
-Metrics shape behavior. Choose them carefully so teams optimize for what users actually value.
+## Understand your metric types
 
-## Metric taxonomy
+Pick the right evaluation instrument for the decision at hand.
 
 | Type | When to use | Example |
 | --- | --- | --- |
-| **Binary guardrail** | Hard safety or compliance requirements | "Did the response leak PII?" |
-| **Scalar quality** | Nuanced experience judgments | "Rate the helpfulness from 1 (harmful) to 5 (delight)." |
-| **Comparative** | Ranking model variants | "Which output would you send to the user?" |
-| **Operational** | Product performance and cost | Latency, GPU minutes, or refund rate |
+| **Binary guardrail** | Enforce non-negotiable safety or policy rules | "Did the response leak personal data?" |
+| **Scalar quality** | Capture nuance in usefulness, tone, or accuracy | "Rate the guidance from 1 (harmful) to 5 (delight)." |
+| **Comparative** | Rank model variants or prompt strategies | "Which answer would you send to the user?" |
+| **Operational** | Track latency, cost, and throughput | Token cost, GPU minutes, or handoff rate |
 
-## Crafting scalar rubrics
+<Info>
+Use multiple metric types together. A stellar experience score cannot excuse a guardrail violation.
+</Info>
 
-1. **Name each level.** Replace numbers with vivid labels like *Off course*, *On track*, *Exceptional*.
-2. **Anchor with evidence.** Provide an example response for each level and explain *why* it fits.
-3. **Define edge cases.** Clarify how to score partial answers, redactions, or "no response" scenarios.
-
-<Callout icon="scale-balanced" color="teal">
-Even when LLM judges provide the score, write the rubric for humans. Clear, concrete language makes prompts more reliable.
-</Callout>
-
-## Hybrid scoring patterns
+## Craft a resilient rubric
 
 <Steps>
-  <Step title="Human primary, model assist">
-    Start with human ratings to set the gold standard. Use model judges to pre-score and triage the most ambiguous cases.
-  </Step>
-  <Step title="Model primary, human audit">
-    Rely on LLM judges for coverage. Sample 5–10% of items for human review. Track agreement and recalibrate prompts when drift appears.
-  </Step>
-  <Step title="Ensemble scores">
-    Combine heuristics, model ratings, and human judgments into a single composite. Weight components based on risk tolerance.
-  </Step>
+<Step title="Name each level">
+Replace numeric labels with language reviewers remember, such as *Off course*, *On track*, and *Delight*.
+</Step>
+<Step title="Anchor with evidence">
+Pair each level with real examples or transcripts. Explain why the answer earned that rating.
+</Step>
+<Step title="Clarify edge cases">
+Document how to score partial answers, missing context, or "no response" situations.
+</Step>
 </Steps>
 
-## Reporting strategies
+<Tip>
+Even if an LLM judge scores the output, write the rubric for humans. Precise language improves prompt reliability and auditability.
+</Tip>
 
-- **Disaggregate by segment.** Slice by user persona, language, or scenario type to uncover hidden regressions.
-- **Visualize confidence.** Pair mean scores with variance or rater agreement to show stability.
-- **Tell a before/after story.** When experiments improve metrics, include examples that illustrate the change.
+## Blend humans and automation
+
+<CodeGroup>
+```yaml Human primary
+- Humans score all prompts using the rubric
+- LLM judges pre-score to highlight disagreements
+- Weekly audits compare agreement trends
+```
+
+```yaml Model primary
+- LLM judge produces scores with rationale
+- Humans sample 10% of prompts for calibration
+- Trigger a review if agreement drops below 80%
+```
+
+```yaml Ensemble
+- Combine heuristic checks, model ratings, and human spot checks
+- Weight each component based on risk tolerance
+- Rebalance weights during quarterly retrospectives
+```
+</CodeGroup>
+
+## Report with context
+
+- **Disaggregate by segment:** Slice by persona, geography, and scenario to surface hidden regressions.
+- **Visualize confidence:** Pair mean scores with variance or rater agreement so leaders understand stability.
+- **Tell a story:** Highlight an example conversation that illustrates each major insight.
+
+<Check>
+A strong metric program prompts immediate action: ship improvements, investigate regressions, or gather more data.
+</Check>

--- a/guides/principles.mdx
+++ b/guides/principles.mdx
@@ -4,40 +4,58 @@ description: "Anchor your AI evaluation program in values that stand the test of
 icon: "lightbulb"
 ---
 
-Evaluations are cultural artifacts. They communicate what "good" means, who gets to decide, and how seriously you treat quality. Use these principles as your compass.
+## Lead with real user stakes
 
-## 1. Start with a human story
+Evaluations tell a story about the people your AI serves. Start every project with a concrete scenario that captures who is affected, what they need, and why it matters.
 
-<Callout icon="book-open" color="violet">
-Before you collect a single metric, articulate the user story in plain language. Evals grounded in human stakes create empathy and urgency.
-</Callout>
+<Tip>
+Invite customer-facing teammates or real users to review your scenarios. Fresh perspectives uncover blind spots faster than metrics alone.
+</Tip>
 
-- Name the person impacted, not just the persona.
-- Capture the context—constraints, emotions, and success criteria.
-- Invite a real user or customer-facing teammate to validate the story.
+## Measure what truly matters
 
-## 2. Measure what matters, not what's easy
+Guardrails are essential, but they cannot be the whole story. Combine multiple lens:
 
-A/B-friendly metrics are tempting, but superficial signals produce superficial insights. Mix:
+- **Safety and compliance:** Prevent policy violations, sensitive data leaks, and harmful tone.
+- **Experience quality:** Capture usefulness, empathy, and clarity so the model feels trustworthy.
+- **Business impact:** Track cost, efficiency, and retention signals to show why the evaluation matters.
 
-- **Guardrail metrics** that protect safety and compliance.
-- **Experience metrics** that capture usefulness, tone, and trust.
-- **Business metrics** that connect to revenue, retention, or cost.
+<Warning>
+Avoid proxy metrics that reward shortcuts. If a model can game the number, teams will optimize for the wrong behavior.
+</Warning>
 
-## 3. Make disagreement visible
+## Make disagreement visible
 
-Diverse reviewers surface blind spots. Encourage debate and capture it:
+Healthy tension reveals nuance. Record per-rater scores, capture rationales, and highlight the turning points that changed minds.
 
-<Expandable title="How to capture disagreement">
-- Record per-rater scores before discussion.
-- Ask reviewers to annotate why they disagreed and what evidence changed their minds.
-- Store these annotations with the prompt so future reviewers learn faster.
-</Expandable>
+<AccordionGroup>
+<Accordion title="Document productive disagreement">
+- Collect individual scores before any discussion.
+- Ask reviewers to annotate what evidence influenced their final call.
+- Store the conversation alongside the prompt for future calibration.
+</Accordion>
+</AccordionGroup>
 
-## 4. Iterate faster than your model
+## Iterate faster than your model
 
-Ship eval updates as frequently as model updates. Keep a changelog of rubric tweaks, prompt set refreshes, and scoring policy shifts. Pair every release with a smoke test that validates past regressions stay fixed.
+Treat evaluations like software. Version everything, ship updates often, and communicate changes clearly.
 
-## 5. Celebrate the narrative
+<Steps>
+<Step title="Log every change">
+Maintain a changelog for rubric updates, prompt refreshes, and automation tweaks.
+</Step>
+<Step title="Smoke test frequently">
+Re-run past regressions or golden prompts whenever you update the evaluation.
+</Step>
+<Step title="Share release notes">
+Publish short updates so stakeholders know what changed and why confidence remains high.
+</Step>
+</Steps>
 
-Numbers without storytelling rarely inspire action. Use visuals, quotes, and scenarios to bring findings to life. Close with a "director's cut": what surprised you, what you'll watch next, and how product teams can help.
+## Tell a compelling story
+
+Metrics open the door; narratives drive action. Pair charts with user quotes, transcripts, and before/after examples. Close every report with clear guidance on what to do next.
+
+<Check>
+When teams repeat your stories in planning meetings, your evaluation program has become part of the culture.
+</Check>

--- a/index.mdx
+++ b/index.mdx
@@ -1,71 +1,71 @@
 ---
-title: "Welcome"
-description: "Design magnetic evaluations that make AI systems accountable"
+title: "AI evaluation playbook"
+description: "Design, launch, and scale evaluation programs people trust"
 ---
 
-## Build evaluations people trust
+## Launch evaluations with confidence
 
-Great AI products have tight feedback loops. These docs show you how to translate fuzzy expectations into crisp evaluation programs that keep teams aligned and models improving.
+You want an evaluation program that inspires action, not confusion. This guide maps every step—from your first planning workshop to ongoing monitoring—so you can keep quality high while shipping fast.
 
-<Callout icon="sparkles" color="emerald">
-A good eval doesn't just score a model. It tells a story about how the system behaves, why that matters, and what to do next.
-</Callout>
+<Tip>
+Stay outcome-oriented. Before diving into tooling, clarify the user moment and the decision the evaluation will unlock.
+</Tip>
 
-<Columns cols={2}>
-  <Card
-    title="Start designing"
-    icon="compass"
-    href="/quickstart"
-  >
-    Spin up a lightweight evaluation in under an hour with our facilitator prompts and worksheet templates.
-  </Card>
-  <Card
-    title="Run the workflow"
-    icon="shuffle"
-    href="/development"
-  >
-    Stitch together people, prompts, and tooling for repeatable evaluation cycles.
-  </Card>
-  <Card
-    title="Master the craft"
-    icon="lightbulb"
-    href="/guides/principles"
-  >
-    Internalize the principles that make evals meaningful, inclusive, and resilient.
-  </Card>
-  <Card
-    title="Browse playbooks"
-    icon="chess-board"
-    href="/playbooks/manual-review"
-  >
-    Apply ready-to-run playbooks for human review sessions, automated regression sweeps, and live monitoring.
-  </Card>
-</Columns>
+<CardGroup cols={2}>
+<Card title="Quickstart sprint" icon="rocket" href="/quickstart">
+Follow a 60-minute agenda that gets stakeholders aligned, rubrics drafted, and a pilot run completed.
+</Card>
 
-## Choose your next move
+<Card title="Operational workflow" icon="diagram-project" href="/development">
+Translate ideas into a repeatable lifecycle with clear owners, tooling choices, and quality gates.
+</Card>
 
-<Columns cols={3}>
-  <Card
-    title="Calibrate metrics"
-    icon="ruler"
-    href="/guides/metrics"
-  >
-    Mix quantitative signals with qualitative rubrics to capture the full experience.
-  </Card>
-  <Card
-    title="Find the right data"
-    icon="database"
-    href="/guides/data"
-  >
-    Curate scenario libraries, edge-case hunts, and real-user traces without drifting from your ethics policy.
-  </Card>
-  <Card
-    title="Automate wisely"
-    icon="robot"
-    href="/playbooks/automation"
-  >
-    Pair judges, heuristics, and telemetry to keep quality in check at scale.
-  </Card>
-</Columns>
+<Card title="Evaluation principles" icon="lightbulb" href="/guides/principles">
+Adopt guiding principles that keep your program human-centered, resilient, and actionable.
+</Card>
 
-Need a head start? Jump to our [evaluation checklist](/templates/checklist) or remix the [rubric template](/templates/rubric-example) with your own rating language.
+<Card title="Execution playbooks" icon="chess-board" href="/playbooks/manual-review">
+Run manual sessions, automation pipelines, and monitoring cadences that scale with your product roadmap.
+</Card>
+</CardGroup>
+
+## Choose the best next action
+
+<Tabs>
+<Tab title="Design your system">
+<CardGroup cols={2}>
+<Card title="Metrics that matter" icon="ruler" href="/guides/metrics">
+Blend quantitative rigor with qualitative nuance so teams optimize for true user value.
+</Card>
+<Card title="Curate powerful data" icon="database" href="/guides/data">
+Build a scenario library, refresh prompts safely, and capture gold answers that keep regressions in check.
+</Card>
+</CardGroup>
+</Tab>
+
+<Tab title="Ship faster">
+<CardGroup cols={2}>
+<Card title="Manual review" icon="people-group" href="/playbooks/manual-review">
+Facilitate high-energy review sessions that surface nuance and produce clear next steps.
+</Card>
+<Card title="Automation" icon="robot" href="/playbooks/automation">
+Design transparent pipelines that mix heuristics, LLM judges, and telemetry without losing trust.
+</Card>
+</CardGroup>
+</Tab>
+
+<Tab title="Keep it fresh">
+<CardGroup cols={2}>
+<Card title="Monitoring" icon="chart-line" href="/playbooks/monitoring">
+Turn one-off experiments into a living program with tiered alerts, dashboards, and rituals.
+</Card>
+<Card title="Templates" icon="file-pen" href="/templates/checklist">
+Copy evaluation-ready checklists and rubrics that accelerate onboarding and audits.
+</Card>
+</CardGroup>
+</Tab>
+</Tabs>
+
+<Note>
+Need a shortcut? Remix the <a href="/templates/checklist">evaluation checklist</a> or <a href="/templates/rubric-example">rubric template</a> to kick-start your next run.
+</Note>

--- a/playbooks/automation.mdx
+++ b/playbooks/automation.mdx
@@ -4,15 +4,19 @@ description: "Scale evaluation coverage without losing signal"
 icon: "robot"
 ---
 
-Automation extends your reach so you can catch regressions before users do. Use this playbook to design pipelines that are fast, transparent, and trustworthy.
+## Why automate
 
-## When to automate
+Automation catches regressions early, provides consistent coverage, and frees humans to focus on nuance. Use it to augment—not replace—expert judgment.
 
 | Signal | Automate when... | Stay manual when... |
 | --- | --- | --- |
-| Guardrail checks | Rules rarely change and failures are binary | Policies are evolving or context heavy |
-| LLM judge scoring | Rubric language is crisp and pilot agreement >80% | Stakes are high or disagreement remains high |
-| Regression suites | Prompts are stable and map to specific release criteria | You're still exploring what "good" looks like |
+| Guardrail checks | Policies are stable and violations are binary | Rules are evolving or context heavy |
+| LLM judge scoring | Rubric language is crisp and pilot agreement > 80% | Stakes are high or disagreement remains high |
+| Regression suites | Prompts map to specific release criteria | You are still exploring what “good” looks like |
+
+<Tip>
+Start with a nightly run against a small, high-impact prompt set. Expand coverage as confidence grows.
+</Tip>
 
 ## Architecture blueprint
 
@@ -30,26 +34,42 @@ Automation extends your reach so you can catch regressions before users do. Use 
 
 ## Prompting LLM judges
 
-- **Mirror the rubric.** Paste the exact evaluation rubric into the system prompt.
-- **Ask for rationale.** Request a short explanation along with the score for auditing.
-- **Calibrate temperature.** Set `temperature=0` for determinism. Use `top_p` or `logprobs` if available to gauge confidence.
+<Steps>
+<Step title="Mirror the rubric">
+Paste the exact evaluation rubric into the system prompt. Clarity prevents drift over time.
+</Step>
+<Step title="Capture rationale">
+Request a concise explanation with each score for auditing and debugging.
+</Step>
+<Step title="Tune determinism">
+Set `temperature=0` and monitor log probabilities or confidence outputs where available.
+</Step>
+</Steps>
 
-## Monitoring drift
+<Warning>
+Never ship automated scores without a human-reviewed pilot. Validate agreement and false-positive rates first.
+</Warning>
 
-<Accordion>
-  <AccordionItem title="Agreement tracking">
-    Compare model-judge scores with periodic human audits. Trigger retraining if agreement falls below your threshold.
-  </AccordionItem>
-  <AccordionItem title="Data freshness">
-    Alert when a scenario hasn't been updated in >60 days or when product changes invalidate prompts.
-  </AccordionItem>
-  <AccordionItem title="Latency & cost">
-    Visualize runtime and spend per run. Highlight outliers to optimize infrastructure.
-  </AccordionItem>
+## Monitor drift
+
+<AccordionGroup>
+<Accordion title="Agreement tracking">
+Compare model-judge scores with periodic human audits. Trigger retraining when agreement falls below your threshold.
 </Accordion>
+<Accordion title="Data freshness">
+Alert when a scenario has not been updated in 60 days or product changes invalidate prompts.
+</Accordion>
+<Accordion title="Latency and cost">
+Track runtime and spend per run. Highlight outliers and optimize infrastructure regularly.
+</Accordion>
+</AccordionGroup>
 
-## Communicating results
+## Communicate results
 
-- Pipe critical regressions into incident channels with owner tags.
-- Share weekly digests that combine quantitative trends with a "story of the week" example.
-- Provide self-serve dashboards for product teams to explore their features.
+- Pipe critical regressions into incident channels with owner tags and remediation guidance.
+- Share weekly digests that combine quantitative trends with a “story of the week” example.
+- Provide self-serve dashboards so product teams can explore their features in detail.
+
+<Check>
+Automation succeeds when stakeholders trust the alerts enough to act immediately.
+</Check>

--- a/playbooks/manual-review.mdx
+++ b/playbooks/manual-review.mdx
@@ -4,46 +4,69 @@ description: "Facilitate high-energy human evaluation sessions"
 icon: "people-group"
 ---
 
-Manual review unlocks nuance that automation misses. Here's how to run engaging sessions that produce consistent, actionable insights.
+## Purpose
+
+Manual review sessions surface nuance that automation misses. Use this playbook to design meetings that keep reviewers energized and outputs actionable.
+
+<Info>
+Audience: evaluation facilitators and product partners preparing recurring review sessions.
+</Info>
 
 ## Prep checklist
 
-<Checklist>
-  <ChecklistItem>Agenda with timeboxes for calibration, scoring, and synthesis</ChecklistItem>
-  <ChecklistItem>Rubric printouts or shared docs with rating scales and examples</ChecklistItem>
-  <ChecklistItem>Prompt set tagged by scenario type and risk level</ChecklistItem>
-  <ChecklistItem>Note-taking template to capture quotes, questions, and follow-ups</ChecklistItem>
-</Checklist>
+<Steps>
+<Step title="Set the agenda">
+Timebox calibration, scoring, and synthesis segments. Share goals and success criteria beforehand.
+</Step>
+<Step title="Distribute artifacts">
+Send the rubric, prompt set, and note-taking template at least a day before the session.
+</Step>
+<Step title="Assign roles">
+Confirm facilitator, scribe, and decision owner. Clarify how disagreements will be resolved.
+</Step>
+</Steps>
 
 ## Facilitation agenda
 
 <Steps>
-  <Step title="Warm-up (5 min)">
-    Share the evaluation goal and what's new since the last session. Invite reviewers to share a recent user story that inspired them.
-  </Step>
-  <Step title="Calibration (10 min)">
-    Review 2–3 sample prompts together. Score silently, then compare. Highlight disagreements and adjust rubric language.
-  </Step>
-  <Step title="Scoring rounds (25 min)">
-    Split into pairs or trios. Rotate through prompts, capturing scores and rationale. Encourage "think aloud" commentary.
-  </Step>
-  <Step title="Synthesis (10 min)">
-    Regroup to surface patterns. Vote on top issues to escalate and biggest wins to celebrate.
-  </Step>
+<Step title="Warm-up (5 min)">
+Revisit the evaluation goal and highlight what changed since the last run. Invite a recent user story to set context.
+</Step>
+<Step title="Calibration (10 min)">
+Score two example prompts silently, then debate differences. Update rubric language live to reduce ambiguity.
+</Step>
+<Step title="Scoring rounds (25 min)">
+Split into pairs or trios. Capture scores and rationales in your shared tracker. Encourage "think aloud" commentary.
+</Step>
+<Step title="Synthesis (10 min)">
+Group top insights, vote on priority issues, and assign next steps with due dates.
+</Step>
 </Steps>
 
-## Energizers and rituals
+<Tip>
+Keep energy high with small rituals—a "quote of the day," shout-outs for bias spotting, or quick stretch breaks.
+</Tip>
 
-- Play a "quote of the day" game with surprising user lines.
-- Award a "bias buster" badge to the reviewer who spots a hidden assumption.
-- Close with a gratitude round—who made the evaluation easier this week?
+## Turn insights into action
 
-## Turning insights into action
+- Document the top three issues with reproduction steps and example transcripts.
+- Share standout wins to reinforce what "delight" looks like.
+- Schedule follow-up experiments and confirm owners before ending the session.
 
-<Callout icon="bolt" color="lime">
-Before ending the session, translate findings into concrete experiments. Assign owners and deadlines while energy is still high.
-</Callout>
+<Check>
+Send a recap within 24 hours capturing decisions, blockers, and upcoming experiments. Momentum fades quickly without clear communication.
+</Check>
 
-1. Document the top three issues in your tracker with reproduction steps.
-2. Link to supporting examples (screenshots, transcripts, ratings).
-3. Schedule a follow-up check-in to confirm fixes before the next release.
+## Troubleshooting
+
+<AccordionGroup>
+<Accordion title="Reviewers arrive unprepared">
+Start with a micro-calibration and extend the session by 10 minutes. Follow up with pre-read reminders for next time.
+</Accordion>
+<Accordion title="Conversation drifts off-topic">
+Park unrelated issues in a shared doc. Revisit them after the session so scoring stays focused.
+</Accordion>
+<Accordion title="Bias creeps into scoring">
+Rotate reviewer pairs and anonymize prompts when possible. Highlight bias mitigation wins in the recap.
+</Accordion>
+</AccordionGroup>

--- a/playbooks/monitoring.mdx
+++ b/playbooks/monitoring.mdx
@@ -4,42 +4,54 @@ description: "Keep evaluations alive after launch"
 icon: "chart-line"
 ---
 
-Evaluations shouldn't gather dust after a launch. This playbook helps you turn one-off experiments into a living monitoring program.
+## Establish alert tiers
 
-## Define alerting tiers
+Define who responds to quality regressions and how quickly.
 
 | Tier | Description | Owner | Example trigger |
 | --- | --- | --- | --- |
 | **P0** | Immediate action required | On-call product lead | Safety guardrail failure > 0.5% |
-| **P1** | Investigate within a day | Evaluation program manager | Experience score drops > 0.3 week-over-week |
+| **P1** | Investigate within one day | Evaluation program manager | Experience score drops > 0.3 week-over-week |
 | **P2** | Track over time | Feature owner | Gradual latency increase across scenarios |
 
-## Instrument your dashboards
+<Warning>
+Without explicit owners, alerts drown in noise. Document who investigates and how to escalate.
+</Warning>
 
-- **Narrative widgets:** Combine charts with analyst commentary so stakeholders understand the "why".
-- **Drill-through examples:** Link each metric to underlying conversations or prompts for fast root cause analysis.
+## Instrument dashboards
+
+- **Narrative widgets:** Pair charts with analyst commentary so stakeholders understand the “why.”
+- **Drill-through examples:** Link every metric to transcripts or screenshots for rapid root-cause analysis.
 - **Health checklist:** Highlight when datasets, rubrics, or judge prompts are due for refresh.
+
+<Tip>
+Use color-blind-friendly palettes and include keyboard shortcuts so dashboards stay accessible.
+</Tip>
 
 ## Create a monitoring cadence
 
 <Steps>
-  <Step title="Daily pulse">
-    Quick scan for P0 incidents. Triage with engineering if guardrails trip.
-  </Step>
-  <Step title="Weekly sync">
-    Review evaluation trends with product and research partners. Decide which regressions warrant experiments.
-  </Step>
-  <Step title="Monthly retrospective">
-    Reflect on rubric effectiveness, dataset freshness, and automation coverage. Update your roadmap accordingly.
-  </Step>
+<Step title="Daily pulse">
+Scan for P0 incidents and trigger incident response if guardrails fail.
+</Step>
+<Step title="Weekly sync">
+Review trends with product, research, and support partners. Decide which regressions warrant experiments.
+</Step>
+<Step title="Monthly retrospective">
+Assess rubric effectiveness, dataset freshness, and automation coverage. Update your roadmap accordingly.
+</Step>
 </Steps>
 
 ## Feedback loop rituals
 
-<Callout icon="repeat" color="cyan">
-Send a celebratory recap when metrics rebound or a regression is crushed. Reinforcing wins keeps teams engaged with the program.
-</Callout>
+<Info>
+Celebrate rebounds and resolved regressions. Recognizing wins keeps teams invested in evaluation quality.
+</Info>
 
-- Host "eval office hours" for teams launching new features.
-- Publish a changelog that logs dataset, rubric, and pipeline updates.
+- Host “eval office hours” for teams launching new features.
+- Publish a changelog documenting dataset, rubric, and pipeline updates.
 - Invite leadership to quarterly readouts featuring user stories and strategic bets influenced by evaluation insights.
+
+<Check>
+Monitoring is working when stakeholders resolve issues before customers notice them.
+</Check>

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -1,53 +1,82 @@
 ---
 title: "Quickstart"
-description: "Launch an evaluation sprint in under an hour"
+description: "Run your first evaluation sprint in under an hour"
 ---
 
-You're minutes away from turning intuition into evidence. This quickstart walks a cross-functional team through their first evaluation sprint—whether you're validating a brand-new model or checking that a release candidate still delights users.
+## Overview
 
-## 1. Align on the outcome
+You can launch a credible evaluation sprint with a single working session. This quickstart keeps you focused on decisions, evidence, and momentum so you finish with a repeatable workflow—not just a meeting recap.
+
+<Info>
+Audience: product, research, and data leaders standing up their first AI evaluation. Outcome: an aligned decision statement, draft rubric, pilot results, and action plan.
+</Info>
+
+## Prerequisites
+
+- Core product scenario you want to validate
+- Access to 10–20 representative prompts and responses
+- Decision-maker who can commit to next steps
+
+## Sprint agenda
 
 <Steps>
-  <Step title="Define the decision">
-    What will this evaluation help you decide? Common answers include *ship vs. fix*, *which prompt wins*, or *where to invest data collection*. Write the decision in one sentence and share it with the team.
-  </Step>
-  <Step title="Summarize the user moment">
-    Describe the exact scenario you care about. Capture who the user is, what they are trying to accomplish, and why the moment matters.
-  </Step>
-  <Step title="List success signals">
-    Brainstorm what "good" looks like. Mix objective signals (accuracy, latency, adherence) with subjective ones (tone, confidence). You'll refine these into metrics shortly.
-  </Step>
+<Step title="Frame the decision (15 min)">
+Capture the user moment, the business risk, and the choice you need to make. Write the decision in one sentence and share it with the group.
+
+<Check>
+You have a clear statement such as: "Decide whether Model B is ready to replace Model A for refund chats." 
+</Check>
+</Step>
+
+<Step title="Draft the rubric (20 min)">
+Translate success signals into a 3–5 level rating scale. Pair each level with concrete evidence or example responses.
+
+<Tip>
+Use vivid labels—"Delight," "Fix now"—so reviewers remember what each rating means.
+</Tip>
+</Step>
+
+<Step title="Pilot the workflow (15 min)">
+Run through 5 sample prompts. Capture disagreements, confusing rubric language, and missing context.
+
+<Warning>
+Stop and revise if reviewers disagree on more than half the prompts. Misalignment now becomes chaos later.
+</Warning>
+</Step>
+
+<Step title="Commit to actions (10 min)">
+Summarize findings, assign owners, and schedule the next full run. Publish the decision statement, rubric draft, and pilot notes in your shared workspace.
+</Step>
 </Steps>
 
-## 2. Assemble your eval kit
+## Post-sprint checklist
 
-<Checklist>
-  <ChecklistItem>10–20 real or realistic prompts that illustrate the user moment</ChecklistItem>
-  <ChecklistItem>A draft rubric that translates success signals into 3–5 rating levels</ChecklistItem>
-  <ChecklistItem>At least one example response for each rating level</ChecklistItem>
-  <ChecklistItem>Owners for facilitation, note taking, and follow-up actions</ChecklistItem>
-</Checklist>
+- Version control the rubric and prompt set
+- Decide how you will collect scores (humans, LLM judge, or hybrid)
+- Announce the next evaluation date and success criteria
 
-Use our [rubric template](/templates/rubric-example) if you need a starting point. Keep the rubric language vivid—reviewers should feel the difference between a "meh" output and a "nailed it" response.
+<Check>
+Share a short recap with stakeholders highlighting the decision, top insight, and immediate next experiment.
+</Check>
 
-## 3. Run a pilot session
+## Troubleshooting
 
-<Callout icon="person-chalkboard" color="amber">
-Bring together 2–3 reviewers for a 30-minute dry run. Encourage debate about borderline ratings and document how they resolved disagreements.
-</Callout>
+<AccordionGroup>
+<Accordion title="We cannot agree on ratings">
+Pause the pilot and rewrite the rubric examples using real transcripts. Consider splitting complex prompts into multiple scenarios.
+</Accordion>
 
-During the session:
+<Accordion title="We lack enough prompts">
+Sample from production conversations or support tickets, then de-identify sensitive details. Synthetic prompts are helpful but should not dominate the set.
+</Accordion>
 
-- Timebox each prompt to keep energy high.
-- Capture quotes or screenshots that illustrate each rating.
-- Highlight confusing rubric language and revise on the fly.
+<Accordion title="Stakeholders want more rigor first">
+Run a second pilot with a different reviewer group. Present the disagreement notes and updated rubric to build confidence before scaling.
+</Accordion>
+</AccordionGroup>
 
-## 4. Lock the workflow
+## Next steps
 
-Once the pilot feels smooth, codify the process:
-
-1. **Data source:** Where will prompts and context come from? Ensure you can refresh them later.
-2. **Scoring path:** Decide whether humans, an LLM judge, or a hybrid approach will produce scores.
-3. **Reporting cadence:** Outline who receives the summary and how quickly they should act on regressions.
-
-Document these decisions in your project tracker. Congratulations—you now have a living evaluation you can repeat, automate, and scale.
+<Note>
+Promote the sprint outcome into a living evaluation by following the <a href="/development">evaluation workflow</a>. When you are ready, automate pieces with the <a href="/playbooks/automation">automation playbook</a>.
+</Note>

--- a/templates/checklist.mdx
+++ b/templates/checklist.mdx
@@ -4,33 +4,60 @@ description: "A repeatable list to keep every run sharp"
 icon: "square-check"
 ---
 
-Use this checklist before, during, and after each evaluation cycle. Duplicate it into your project tracker and customize as needed.
-
 ## Before the run
 
-<Checklist>
-  <ChecklistItem>Decision statement documented and shared</ChecklistItem>
-  <ChecklistItem>Latest rubric reviewed and signed off</ChecklistItem>
-  <ChecklistItem>Prompt set refreshed with current scenarios</ChecklistItem>
-  <ChecklistItem>Reviewer roster confirmed (or LLM judge prompt validated)</ChecklistItem>
-  <ChecklistItem>Data privacy review completed for new examples</ChecklistItem>
-</Checklist>
+<Steps>
+<Step title="Clarify the decision">
+Document the decision statement and share it with stakeholders.
+</Step>
+<Step title="Confirm artifacts">
+Review the latest rubric, prompt set, and judge prompts. Version them in source control.
+</Step>
+<Step title="Check compliance">
+Complete any required privacy or policy reviews for new examples.
+</Step>
+<Step title="Secure reviewers">
+Confirm human reviewers or validate the LLM judge prompt with a pilot run.
+</Step>
+</Steps>
 
 ## During the run
 
-<Checklist>
-  <ChecklistItem>Calibration examples reviewed at the start</ChecklistItem>
-  <ChecklistItem>Scores captured with rationale or citations</ChecklistItem>
-  <ChecklistItem>Disagreements logged for later analysis</ChecklistItem>
-  <ChecklistItem>Incidents escalated immediately through the agreed channel</ChecklistItem>
-</Checklist>
+<Steps>
+<Step title="Calibrate">
+Review calibration examples before scoring begins.
+</Step>
+<Step title="Capture evidence">
+Record scores with rationales or citations for each prompt.
+</Step>
+<Step title="Log incidents">
+Escalate safety or policy violations through the agreed channel immediately.
+</Step>
+<Step title="Track disagreements">
+Note disagreements and resolution steps for future training.
+</Step>
+</Steps>
 
 ## After the run
 
-<Checklist>
-  <ChecklistItem>Summary doc published with top insights and actions</ChecklistItem>
-  <ChecklistItem>Tickets created for follow-up experiments or fixes</ChecklistItem>
-  <ChecklistItem>Metrics and examples added to the monitoring dashboard</ChecklistItem>
-  <ChecklistItem>Evaluation artifacts versioned in source control</ChecklistItem>
-  <ChecklistItem>Retrospective scheduled to improve the next cycle</ChecklistItem>
-</Checklist>
+<Steps>
+<Step title="Publish insights">
+Share a summary highlighting wins, regressions, and recommended actions.
+</Step>
+<Step title="Create follow-ups">
+Open tickets for experiments, fixes, or data collection tasks.
+</Step>
+<Step title="Update dashboards">
+Add metrics and examples to your monitoring workspace.
+</Step>
+<Step title="Version artifacts">
+Commit updated rubrics, prompts, and judge prompts with clear changelog entries.
+</Step>
+<Step title="Schedule retrospective">
+Book time to improve the next cycle and celebrate outcomes.
+</Step>
+</Steps>
+
+<Check>
+When every step above is complete, your evaluation run is ready for leadership review.
+</Check>

--- a/templates/rubric-example.mdx
+++ b/templates/rubric-example.mdx
@@ -4,45 +4,59 @@ description: "Customize this rubric to judge your AI system"
 icon: "table-list"
 ---
 
-Copy this rubric into your favorite evaluation tool or LLM judge prompt. Adjust the scenario description and rating language to match your product.
+## How to use this template
 
-<Callout icon="wand-magic" color="purple">
-For best results, pair each rating with a real example from your dataset.
-</Callout>
+Copy the sections below into your evaluation tool or LLM judge prompt. Replace the bracketed text with details from your scenario.
 
-### Scenario
+<Tip>
+Pair every rating with a real transcript before sharing the rubric with reviewers or models.
+</Tip>
 
-```
-User: [Describe the user persona and context]
+## Scenario context
+
+```text
+User: [Describe the persona and situation]
 Task: [Explain what they are trying to accomplish]
-Model: [Specify which model or configuration you're evaluating]
+Model: [Specify the model or configuration under review]
 ```
 
-### Rating scale
+## Rating scale
 
 | Rating | Label | Description | Example evidence |
 | --- | --- | --- | --- |
-| 5 | Exceptional | Response fully solves the task, anticipates follow-up questions, and matches the user's tone. | "The assistant not only provides the refund steps but also offers to stay on chat until the user confirms success." |
-| 4 | Strong | Response addresses the task with minor omissions or stylistic issues. | "Instructions are correct but lack empathy after a stressful experience." |
-| 3 | Mixed | Response partially solves the task or requires user effort to apply. | "Gives relevant policy info but forgets to provide the actual refund link." |
-| 2 | Weak | Response misunderstands the request or omits critical steps. | "Explains what refunds are but doesn't answer the user's specific question." |
-| 1 | Harmful | Response violates policy, is offensive, or fabricates instructions. | "Invents a phone number and encourages the user to share sensitive data." |
+| 5 | Exceptional | Solves the task end-to-end, anticipates follow-up needs, and matches the user’s tone. | "The assistant provides refund steps, confirms policy, and offers to stay until the issue is resolved." |
+| 4 | Strong | Addresses the task with minor omissions or stylistic issues. | "Instructions are correct but empathy fades toward the end." |
+| 3 | Mixed | Partially solves the task and requires user effort to apply. | "Gives policy info but misses the refund link." |
+| 2 | Weak | Misunderstands the request or omits critical steps. | "Explains refunds generally without answering the user’s question." |
+| 1 | Harmful | Violates policy, invents facts, or uses offensive language. | "Invents a phone number and requests sensitive data." |
 
-### Additional notes
+## Reviewer prompts
 
-- **Policy flags:** Did the response break a safety or compliance rule?
-- **Delight moments:** Did the response go above and beyond in a way worth sharing?
-- **Follow-up ideas:** Experiments or data needs inspired by this prompt.
+<Steps>
+<Step title="Score the response">
+Assign a rating from 1–5 using the table above.
+</Step>
+<Step title="Capture rationale">
+Explain what evidence drove your rating. Call out any policy concerns or missing context.
+</Step>
+<Step title="Suggest follow-up">
+List experiments, data needs, or documentation updates inspired by this prompt.
+</Step>
+</Steps>
 
-### LLM judge prompt (optional)
+## Optional: LLM judge prompt
 
-```
-You are an expert reviewer evaluating responses from an AI assistant. Use the rubric below to score the assistant's answer.
+```text
+You are an expert evaluator reviewing AI assistant responses. Use the rubric provided to score the answer.
 
-[Paste rating scale]
-
-Return JSON with fields: {
-  "score": <1-5 integer>,
-  "rationale": "<concise explanation>"
+Return JSON with:
+{
+  "score": <integer 1-5>,
+  "rationale": "<concise explanation>",
+  "policy_flag": <true|false>
 }
 ```
+
+<Warning>
+Run a human-reviewed pilot before trusting automated scores. Validate agreement rates and false positives.
+</Warning>


### PR DESCRIPTION
## Summary
- rewrite the landing page and quickstart to provide clearer navigation and actionable guidance
- refresh workflow, guide, and playbook pages with consistent Mintlify components and troubleshooting tips
- update rubric and checklist templates to use step-driven instructions and automation-ready prompts

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d7a515c3b0832a80f28f7439818e13