### PR TITLE
Add AI intro and LLM section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -18,7 +18,8 @@
             "pages": [
               "index",
               "quickstart",
-              "development"
+              "development",
+              "guides/ai-llms"
             ]
           },
           {

--- a/guides/ai-llms.mdx
+++ b/guides/ai-llms.mdx
@@ -1,0 +1,61 @@
+---
+title: "AI and LLMs 101"
+description: "A practical introduction to Artificial Intelligence and Large Language Models"
+---
+
+## What is AI?
+
+Artificial Intelligence (AI) refers to computer systems designed to perform tasks that typically require human intelligence—understanding language, recognizing patterns, making decisions, or generating content.
+
+<Info>
+In this playbook, we focus on AI systems that process and generate natural language to power product experiences.
+</Info>
+
+## What are LLMs?
+
+Large Language Models (LLMs) are AI models trained on vast text corpora to predict the next token in a sequence. This simple objective, scaled with data and compute, enables capabilities like drafting content, answering questions, summarizing text, and following instructions.
+
+- **Inputs:** prompts, system instructions, and optional context (documents, tools, or structured data)
+- **Outputs:** tokens forming text, code, or structured formats like JSON
+
+## How LLMs work (at a glance)
+
+- **Tokenization:** Text is split into tokens (sub-word units). Models operate over tokens, not characters.
+- **Transformers:** The architecture uses self-attention to weigh relevant context efficiently across long inputs.
+- **Pretraining:** Models learn general language patterns by predicting next tokens on large datasets.
+- **Finetuning & alignment:** Additional training (instruction tuning, RLHF/DPO) steers models toward helpful, honest, and safe behavior.
+
+<Tip>
+Despite impressive outputs, LLMs are probabilistic next-token predictors—not databases or oracles. Always validate critical claims.
+</Tip>
+
+## Strengths and limits
+
+- **Strengths:** rapid drafting, summarization, translation, pattern recognition in text, flexible interfaces
+- **Limits:** hallucinations, outdated knowledge, sensitivity to prompt phrasing, difficulty with precise computation or long reasoning without scaffolding
+
+<Warning>
+Never rely solely on model outputs for high-risk domains without human review, guardrails, and clear escalation paths.
+</Warning>
+
+## Common terms
+
+- **Prompt:** The instructions and context provided to the model
+- **Context window:** Maximum tokens of input plus output the model can handle at once
+- **Temperature/top‑p:** Parameters that control randomness and diversity of outputs
+- **System prompt:** High-level guidance that sets persona, goals, or constraints
+- **Tools/functions:** External capabilities the model can call (search, code execution, databases)
+
+## Choosing a model
+
+Match the model to the job:
+
+- **General assistants:** Balanced instruction-following and safety
+- **Reasoning tasks:** Models trained for extended or multi-step reasoning
+- **Cost-sensitive flows:** Smaller or open models with prompt engineering and evaluation
+- **Private data or latency needs:** On-prem or edge-deployed models with tight context windows
+
+<Note>
+Evaluate models against your scenarios and rubrics. Track agreement between human reviews and automated judges before broad rollout.
+</Note>
+

--- a/guides/ai-llms.mdx
+++ b/guides/ai-llms.mdx
@@ -5,57 +5,51 @@ description: "A practical introduction to Artificial Intelligence and Large Lang
 
 ## What is AI?
 
-Artificial Intelligence (AI) refers to computer systems designed to perform tasks that typically require human intelligence—understanding language, recognizing patterns, making decisions, or generating content.
+Artificial Intelligence (AI) refers to systems that perform language understanding, pattern recognition, decision-making, and content generation.
 
 <Info>
-In this playbook, we focus on AI systems that process and generate natural language to power product experiences.
+This playbook focuses on language AI that powers product experiences.
 </Info>
 
 ## What are LLMs?
 
-Large Language Models (LLMs) are AI models trained on vast text corpora to predict the next token in a sequence. This simple objective, scaled with data and compute, enables capabilities like drafting content, answering questions, summarizing text, and following instructions.
-
-- **Inputs:** prompts, system instructions, and optional context (documents, tools, or structured data)
-- **Outputs:** tokens forming text, code, or structured formats like JSON
+Large Language Models (LLMs) predict the next token to generate text, code, and summaries from prompts and optional context.
 
 ## How LLMs work (at a glance)
 
-- **Tokenization:** Text is split into tokens (sub-word units). Models operate over tokens, not characters.
-- **Transformers:** The architecture uses self-attention to weigh relevant context efficiently across long inputs.
-- **Pretraining:** Models learn general language patterns by predicting next tokens on large datasets.
-- **Finetuning & alignment:** Additional training (instruction tuning, RLHF/DPO) steers models toward helpful, honest, and safe behavior.
+- **Tokenization:** Text is split into subword tokens.
+- **Transformers:** Self-attention weighs relevant context across long inputs.
+- **Training:** Pretraining plus alignment (instruction tuning, RLHF/DPO) steers behavior.
 
 <Tip>
-Despite impressive outputs, LLMs are probabilistic next-token predictors—not databases or oracles. Always validate critical claims.
+Treat outputs as plausible text, not facts—verify critical claims.
 </Tip>
 
 ## Strengths and limits
 
-- **Strengths:** rapid drafting, summarization, translation, pattern recognition in text, flexible interfaces
-- **Limits:** hallucinations, outdated knowledge, sensitivity to prompt phrasing, difficulty with precise computation or long reasoning without scaffolding
+- **Strengths:** drafting, summarization, Q&A, translation, flexible interfaces
+- **Limits:** hallucinations, outdated knowledge, prompt sensitivity, weak math/logic without scaffolding
 
 <Warning>
-Never rely solely on model outputs for high-risk domains without human review, guardrails, and clear escalation paths.
+Use human review and guardrails for high‑risk flows.
 </Warning>
 
 ## Common terms
 
-- **Prompt:** The instructions and context provided to the model
-- **Context window:** Maximum tokens of input plus output the model can handle at once
-- **Temperature/top‑p:** Parameters that control randomness and diversity of outputs
-- **System prompt:** High-level guidance that sets persona, goals, or constraints
-- **Tools/functions:** External capabilities the model can call (search, code execution, databases)
+- **Prompt:** Instructions and context for the model
+- **Context window:** Max tokens of input plus output
+- **Temperature/top‑p:** Controls randomness/diversity
+- **Tools/functions:** External calls (search, code, databases)
 
 ## Choosing a model
 
 Match the model to the job:
 
-- **General assistants:** Balanced instruction-following and safety
-- **Reasoning tasks:** Models trained for extended or multi-step reasoning
-- **Cost-sensitive flows:** Smaller or open models with prompt engineering and evaluation
-- **Private data or latency needs:** On-prem or edge-deployed models with tight context windows
+- **General purpose:** Balanced instruction-following and safety
+- **Reasoning-focused:** Trained for multi-step reasoning
+- **Cost/latency constrained:** Smaller/open or on‑prem/edge deployments
 
 <Note>
-Evaluate models against your scenarios and rubrics. Track agreement between human reviews and automated judges before broad rollout.
+Evaluate on your scenarios and rubrics; track agreement with human reviews.
 </Note>
 


### PR DESCRIPTION
Add a new 'AI and LLMs 101' guide to the documentation to introduce core concepts.

---
<a href="https://cursor.com/background-agent?bcId=bc-887a6191-6132-4b68-a79a-6a76a8080ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-887a6191-6132-4b68-a79a-6a76a8080ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

